### PR TITLE
fw: Move Secure settings to CMSettings

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -1515,10 +1515,10 @@ public final class Settings {
             // At one time in System, then Global, but now back in Secure
             MOVED_TO_SECURE.add(Secure.INSTALL_NON_MARKET_APPS);
 
-            MOVED_TO_SECURE.add(Secure.DEV_FORCE_SHOW_NAVBAR);
-            MOVED_TO_SECURE.add(Secure.KEYBOARD_BRIGHTNESS);
-            MOVED_TO_SECURE.add(Secure.BUTTON_BRIGHTNESS);
-            MOVED_TO_SECURE.add(Secure.BUTTON_BACKLIGHT_TIMEOUT);
+            MOVED_TO_SECURE.add(System.DEV_FORCE_SHOW_NAVBAR);
+            MOVED_TO_SECURE.add(System.KEYBOARD_BRIGHTNESS);
+            MOVED_TO_SECURE.add(System.BUTTON_BRIGHTNESS);
+            MOVED_TO_SECURE.add(System.BUTTON_BACKLIGHT_TIMEOUT);
         }
 
         private static final HashSet<String> MOVED_TO_GLOBAL;
@@ -2531,7 +2531,7 @@ public final class Settings {
          * @deprecated
          * @hide
          */
-        public static final String KEYBOARD_BRIGHTNESS = Secure.KEYBOARD_BRIGHTNESS;
+        public static final String KEYBOARD_BRIGHTNESS = "keyboard_brightness";
 
         /**
          * The button brightness to be used while the screen is on or after a button press,
@@ -2540,7 +2540,7 @@ public final class Settings {
          * @deprecated
          * @hide
          */
-        public static final String BUTTON_BRIGHTNESS = Secure.BUTTON_BRIGHTNESS;
+        public static final String BUTTON_BRIGHTNESS = "button_brightness";
 
         /**
          * The time in ms to keep the button backlight on after pressing a button.
@@ -2548,7 +2548,7 @@ public final class Settings {
          * @deprecated
          * @hide
          */
-        public static final String BUTTON_BACKLIGHT_TIMEOUT = Secure.BUTTON_BACKLIGHT_TIMEOUT;
+        public static final String BUTTON_BACKLIGHT_TIMEOUT = "button_backlight_timeout";
 
         /** Whether to allow one finger quick settings expansion on the right side of the statusbar.
          *
@@ -2990,10 +2990,10 @@ public final class Settings {
 
         /**
         * Developer options - Navigation Bar show switch
-        * @deprecated
+        * @deprecated Moved to CMSettings.Secure.DEV_FORCE_SHOW_NAVBAR
         * @hide
         */
-        public static final String DEV_FORCE_SHOW_NAVBAR = Secure.DEV_FORCE_SHOW_NAVBAR;
+        public static final String DEV_FORCE_SHOW_NAVBAR = "dev_force_show_navbar";
 
 
         /**
@@ -4735,24 +4735,6 @@ public final class Settings {
         public static final String ADB_ENABLED = Global.ADB_ENABLED;
 
         /**
-         * Whether to display the ADB notification.
-         * @hide
-         */
-        public static final String ADB_NOTIFY = "adb_notify";
-
-        /**
-         * The TCP/IP port to run ADB on, or -1 for USB
-         * @hide
-         */
-        public static final String ADB_PORT = "adb_port";
-
-        /**
-         * The hostname for this device
-         * @hide
-         */
-        public static final String DEVICE_HOSTNAME = "device_hostname";
-
-        /**
          * Setting to allow mock locations and location provider status to be injected into the
          * LocationManager service for testing purposes during application development.  These
          * locations and status values  override actual location and status information generated
@@ -6012,12 +5994,6 @@ public final class Settings {
         public static final String SCREENSAVER_DEFAULT_COMPONENT = "screensaver_default_component";
 
         /**
-         * Whether to allow killing of the foreground app by long-pressing the Back button
-         * @hide
-         */
-        public static final String KILL_APP_LONGPRESS_BACK = "kill_app_longpress_back";
-
-        /**
          * The default NFC payment component
          * @hide
          */
@@ -6174,11 +6150,6 @@ public final class Settings {
          */
         public static final String SLEEP_TIMEOUT = "sleep_timeout";
 
-         /** Protected Components
-         * @hide
-         */
-        public static final String PROTECTED_COMPONENTS = "protected_components";
-
         /**
          * Controls whether double tap to wake is enabled.
          * @hide
@@ -6195,81 +6166,10 @@ public final class Settings {
         public static final String ASSISTANT = "assistant";
 
         /**
-         * Stored color matrix for LiveDisplay. This is used to allow co-existence with
-         * display tuning done by DisplayAdjustmentUtils when hardware support isn't
-         * available.
-         * @hide
-         */
-        public static final String LIVE_DISPLAY_COLOR_MATRIX = "live_display_color_matrix";
-
-        /**
-         * Whether to include options in power menu for rebooting into recovery or bootloader
-         * @hide
-         */
-        public static final String ADVANCED_REBOOT = "advanced_reboot";
-
-        /**
-         * String to contain power menu actions
-         * @hide
-         */
-        public static final String POWER_MENU_ACTIONS = "power_menu_actions";
-
-        /**
-         * Developer options - Navigation Bar show switch
-         * @hide
-         */
-        public static final String DEV_FORCE_SHOW_NAVBAR = "dev_force_show_navbar";
-
-        /**
-         * The keyboard brightness to be used while the screen is on.
-         * Valid value range is between 0 and {@link PowerManager#getMaximumKeyboardBrightness()}
-         * @hide
-         */
-        public static final String KEYBOARD_BRIGHTNESS = "keyboard_brightness";
-
-        /**
-         * The button brightness to be used while the screen is on or after a button press,
-         * depending on the value of {@link BUTTON_BACKLIGHT_TIMEOUT}.
-         * Valid value range is between 0 and {@link PowerManager#getMaximumButtonBrightness()}
-         * @hide
-         */
-        public static final String BUTTON_BRIGHTNESS = "button_brightness";
-
-        /**
-         * The time in ms to keep the button backlight on after pressing a button.
-         * A value of 0 will keep the buttons on for as long as the screen is on.
-         * @hide
-         */
-        public static final String BUTTON_BACKLIGHT_TIMEOUT = "button_backlight_timeout";
-
-        /**
          * Default theme to use.  If empty, use system.
          * @hide
          */
         public static final String DEFAULT_THEME_PACKAGE = "default_theme_package";
-
-        /**
-         * A '|' delimited list of theme components to apply from the default theme on first boot.
-         * Components can be one or more of the "mods_XXXXXXX" found in
-         * {@link ThemesContract$ThemesColumns}.  Leaving this field blank assumes all components
-         * will be applied.
-         *
-         * ex: mods_icons|mods_overlays|mods_homescreen
-         *
-         * @hide
-         */
-        public static final String DEFAULT_THEME_COMPONENTS = "default_theme_components";
-
-        /**
-         * This will be set to the system's current theme API version when ThemeService starts.
-         * It is useful for when an upgrade from one version of CM to another occurs.
-         * For example, after a user upgrades from CM11 to CM12, the value of this field
-         * might be 19. ThemeService would then change the value to 21. This is useful
-         * when an API change breaks a theme. Themeservice can identify old themes and
-         * unapply them from the system.
-         * @hide
-         */
-        public static final String THEME_PREV_BOOT_API_LEVEL = "theme_prev_boot_api_level";
 
         /**
          * Whether the camera launch gesture should be disabled.
@@ -6344,7 +6244,6 @@ public final class Settings {
             MOUNT_UMS_NOTIFY_ENABLED,
             SLEEP_TIMEOUT,
             DOUBLE_TAP_TO_WAKE,
-            ADVANCED_REBOOT,
             CAMERA_GESTURE_DISABLED
         };
 
@@ -6760,11 +6659,11 @@ public final class Settings {
 
         /**
          * String to contain power menu actions
-         * @deprecated Use {@link android.provider.Settings.Secure#POWER_MENU_ACTIONS} instead
+         * @deprecated Use {@link CMSettings.Secure#POWER_MENU_ACTIONS} instead
          * @hide
          */
         @Deprecated
-        public static final String POWER_MENU_ACTIONS = Secure.POWER_MENU_ACTIONS;
+        public static final String POWER_MENU_ACTIONS = "power_menu_actions";
 
         /**
          * Whether Views are allowed to save their attribute data.
@@ -8402,7 +8301,7 @@ public final class Settings {
         static {
             MOVED_TO_SECURE = new HashSet<String>(1);
             MOVED_TO_SECURE.add(Settings.Global.INSTALL_NON_MARKET_APPS);
-            MOVED_TO_SECURE.add(Settings.Secure.POWER_MENU_ACTIONS);
+            MOVED_TO_SECURE.add(Settings.Global.POWER_MENU_ACTIONS);
         }
 
         /** @hide */

--- a/core/java/com/android/internal/util/cm/ActionUtils.java
+++ b/core/java/com/android/internal/util/cm/ActionUtils.java
@@ -26,7 +26,7 @@ public class ActionUtils {
 
     /**
      * Kills the top most / most recent user application, but leaves out the launcher.
-     * This is function governed by {@link Settings.Secure.KILL_APP_LONGPRESS_BACK}.
+     * This is function governed by {@link CMSettings.Secure.KILL_APP_LONGPRESS_BACK}.
      *
      * @param context the current context, used to retrieve the package manager.
      * @param userId the ID of the currently active user

--- a/packages/SettingsProvider/res/values/defaults.xml
+++ b/packages/SettingsProvider/res/values/defaults.xml
@@ -235,9 +235,6 @@
     <!-- Default for Settings.Secure.NFC_PAYMENT_COMPONENT -->
     <string name="def_nfc_payment_component"></string>
 
-    <!-- Defaults for Settings.System.DEV_FORCE_SHOW_NAVBAR. -->
-    <integer name="def_force_disable_navkeys">0</integer>
-
     <!-- Default for Settings.System.STATUS_BAR_NOTIF_COUNT. -->
     <integer name="def_notif_count">0</integer>
 

--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
@@ -2493,9 +2493,6 @@ class DatabaseHelper extends SQLiteOpenHelper {
             loadIntegerSetting(stmt, Settings.Secure.LONG_PRESS_TIMEOUT,
                     R.integer.def_long_press_timeout_millis);
 
-            loadIntegerSetting(stmt, Settings.System.DEV_FORCE_SHOW_NAVBAR,
-                    R.integer.def_force_disable_navkeys);
-
             loadBooleanSetting(stmt, Settings.Secure.TOUCH_EXPLORATION_ENABLED,
                     R.bool.def_touch_exploration_enabled);
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -494,14 +494,14 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         protected void observe() {
             super.observe();
             ContentResolver resolver = mContext.getContentResolver();
-            resolver.registerContentObserver(Settings.Secure.getUriFor(
-                    Settings.Secure.DEV_FORCE_SHOW_NAVBAR), false, this, UserHandle.USER_ALL);
+            resolver.registerContentObserver(CMSettings.Secure.getUriFor(
+                    CMSettings.Secure.DEV_FORCE_SHOW_NAVBAR), false, this, UserHandle.USER_ALL);
         }
 
         @Override
         public void update() {
-            boolean visible = Settings.Secure.getIntForUser(mContext.getContentResolver(),
-                    Settings.Secure.DEV_FORCE_SHOW_NAVBAR, 0, UserHandle.USER_CURRENT) == 1;
+            boolean visible = CMSettings.Secure.getIntForUser(mContext.getContentResolver(),
+                    CMSettings.Secure.DEV_FORCE_SHOW_NAVBAR, 0, UserHandle.USER_CURRENT) == 1;
 
             if (visible) {
                 forceAddNavigationBar();

--- a/services/Android.mk
+++ b/services/Android.mk
@@ -35,6 +35,8 @@ services := \
 # The convention is to name each service module 'services.$(module_name)'
 LOCAL_STATIC_JAVA_LIBRARIES := $(addprefix services.,$(services))
 
+LOCAL_JAVA_LIBRARIES += org.cyanogenmod.platform.internal
+
 include $(BUILD_JAVA_LIBRARY)
 
 # native library

--- a/services/accessibility/Android.mk
+++ b/services/accessibility/Android.mk
@@ -7,4 +7,6 @@ LOCAL_MODULE := services.accessibility
 LOCAL_SRC_FILES += \
       $(call all-java-files-under,java)
 
+LOCAL_JAVA_LIBRARIES += org.cyanogenmod.platform.internal
+
 include $(BUILD_STATIC_JAVA_LIBRARY)

--- a/services/accessibility/java/com/android/server/accessibility/DisplayAdjustmentUtils.java
+++ b/services/accessibility/java/com/android/server/accessibility/DisplayAdjustmentUtils.java
@@ -26,6 +26,7 @@ import android.os.ServiceManager;
 import android.provider.Settings;
 import android.util.Slog;
 import android.view.accessibility.AccessibilityManager;
+import cyanogenmod.providers.CMSettings;
 
 /**
  * Utility methods for performing accessibility display adjustments.
@@ -76,8 +77,8 @@ public class DisplayAdjustmentUtils {
             return true;
         }
 
-        if (Settings.Secure.getStringForUser(cr,
-                Settings.Secure.LIVE_DISPLAY_COLOR_MATRIX, userId) != null) {
+        if (CMSettings.Secure.getStringForUser(cr,
+                CMSettings.Secure.LIVE_DISPLAY_COLOR_MATRIX, userId) != null) {
             return true;
         }
 
@@ -96,8 +97,8 @@ public class DisplayAdjustmentUtils {
             colorMatrix = multiply(colorMatrix, INVERSION_MATRIX_VALUE_ONLY);
         }
 
-        String adj = Settings.Secure.getStringForUser(cr,
-                Settings.Secure.LIVE_DISPLAY_COLOR_MATRIX, userId);
+        String adj = CMSettings.Secure.getStringForUser(cr,
+                CMSettings.Secure.LIVE_DISPLAY_COLOR_MATRIX, userId);
         if (adj != null) {
             String[] tmp = adj.split(" ");
             if (tmp.length == 16) {

--- a/services/core/java/com/android/server/ConnectivityService.java
+++ b/services/core/java/com/android/server/ConnectivityService.java
@@ -133,6 +133,7 @@ import com.android.server.net.LockdownVpnTracker;
 import com.google.android.collect.Lists;
 import com.google.android.collect.Sets;
 
+import cyanogenmod.providers.CMSettings;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
@@ -642,8 +643,8 @@ public class ConnectivityService extends IConnectivityManager.Stub
         mTrackerHandler = new NetworkStateTrackerHandler(mHandlerThread.getLooper());
 
         // setup our unique device name
-        String hostname = Settings.Secure.getString(context.getContentResolver(),
-                Settings.Secure.DEVICE_HOSTNAME);
+        String hostname = CMSettings.Secure.getString(context.getContentResolver(),
+                CMSettings.Secure.DEVICE_HOSTNAME);
         if (TextUtils.isEmpty(hostname) &&
                 TextUtils.isEmpty(SystemProperties.get("net.hostname"))) {
             String id = Settings.Secure.getString(context.getContentResolver(),

--- a/services/core/java/com/android/server/ThemeService.java
+++ b/services/core/java/com/android/server/ThemeService.java
@@ -66,6 +66,7 @@ import android.util.Log;
 
 import com.android.internal.R;
 import com.android.internal.util.cm.ImageUtils;
+import cyanogenmod.providers.CMSettings;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -345,9 +346,9 @@ public class ThemeService extends IThemeService.Stub {
         final ContentResolver resolver = mContext.getContentResolver();
         int recordedApiLevel = android.os.Build.VERSION.SDK_INT;
         try {
-            recordedApiLevel = Settings.Secure.getInt(resolver,
-                    Settings.Secure.THEME_PREV_BOOT_API_LEVEL);
-        } catch (SettingNotFoundException e) {
+            recordedApiLevel = CMSettings.Secure.getInt(resolver,
+                    CMSettings.Secure.THEME_PREV_BOOT_API_LEVEL);
+        } catch (CMSettings.CMSettingNotFoundException e) {
             recordedApiLevel = -1;
             Log.d(TAG, "Previous api level not found. First time booting?");
         }
@@ -359,8 +360,8 @@ public class ThemeService extends IThemeService.Stub {
 
     private void updateThemeApi() {
         final ContentResolver resolver = mContext.getContentResolver();
-        boolean success = Settings.Secure.putInt(resolver,
-                Settings.Secure.THEME_PREV_BOOT_API_LEVEL, android.os.Build.VERSION.SDK_INT);
+        boolean success = CMSettings.Secure.putInt(resolver,
+                CMSettings.Secure.THEME_PREV_BOOT_API_LEVEL, android.os.Build.VERSION.SDK_INT);
         if (!success) {
             Log.e(TAG, "Unable to store latest API level to secure settings");
         }
@@ -450,8 +451,8 @@ public class ThemeService extends IThemeService.Stub {
         final String defaultThemePkg = Settings.Secure.getString(resolver,
                 Settings.Secure.DEFAULT_THEME_PACKAGE);
         if (!TextUtils.isEmpty(defaultThemePkg)) {
-            String defaultThemeComponents = Settings.Secure.getString(resolver,
-                    Settings.Secure.DEFAULT_THEME_COMPONENTS);
+            String defaultThemeComponents = CMSettings.Secure.getString(resolver,
+                    CMSettings.Secure.DEFAULT_THEME_COMPONENTS);
             List<String> components;
             if (TextUtils.isEmpty(defaultThemeComponents)) {
                 components = ThemeUtils.getAllComponents();

--- a/services/core/java/com/android/server/display/LiveDisplayController.java
+++ b/services/core/java/com/android/server/display/LiveDisplayController.java
@@ -309,8 +309,8 @@ public class LiveDisplayController {
 
         if (mHardware.isSupported(CMHardwareManager.FEATURE_DISPLAY_COLOR_CALIBRATION)) {
             // Clear this out in case of an upgrade
-            Settings.Secure.putStringForUser(mContext.getContentResolver(),
-                    Settings.Secure.LIVE_DISPLAY_COLOR_MATRIX,
+            CMSettings.Secure.putStringForUser(mContext.getContentResolver(),
+                    CMSettings.Secure.LIVE_DISPLAY_COLOR_MATRIX,
                     null,
                     UserHandle.USER_CURRENT);
 
@@ -334,8 +334,8 @@ public class LiveDisplayController {
 
             // For GPU color transform, go thru DisplayAdjustmentUtils in
             // order to coexist with accessibility settings
-            Settings.Secure.putStringForUser(mContext.getContentResolver(),
-                    Settings.Secure.LIVE_DISPLAY_COLOR_MATRIX,
+            CMSettings.Secure.putStringForUser(mContext.getContentResolver(),
+                    CMSettings.Secure.LIVE_DISPLAY_COLOR_MATRIX,
                     colorMatrixStr,
                     UserHandle.USER_CURRENT);
 

--- a/services/core/java/com/android/server/policy/GlobalActions.java
+++ b/services/core/java/com/android/server/policy/GlobalActions.java
@@ -84,6 +84,7 @@ import android.widget.ImageView;
 import android.widget.ImageView.ScaleType;
 import android.widget.ListView;
 import android.widget.TextView;
+import cyanogenmod.providers.CMSettings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -1211,8 +1212,8 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
 
     protected void updatePowerMenuActions() {
         ContentResolver resolver = mContext.getContentResolver();
-        mActions = Settings.Secure.getStringForUser(resolver,
-                Settings.Secure.POWER_MENU_ACTIONS, UserHandle.USER_CURRENT);
+        mActions = CMSettings.Secure.getStringForUser(resolver,
+                CMSettings.Secure.POWER_MENU_ACTIONS, UserHandle.USER_CURRENT);
     }
 
     private BroadcastReceiver mThemeChangeReceiver = new BroadcastReceiver() {

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -881,13 +881,10 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     Settings.Global.POLICY_CONTROL), false, this,
                     UserHandle.USER_ALL);
             resolver.registerContentObserver(Settings.System.getUriFor(
-                    Settings.System.DEV_FORCE_SHOW_NAVBAR), false, this,
-                    UserHandle.USER_ALL);
-            resolver.registerContentObserver(Settings.System.getUriFor(
                     Settings.System.ACCELEROMETER_ROTATION_ANGLES), false, this,
                     UserHandle.USER_ALL);
-            resolver.registerContentObserver(Settings.Secure.getUriFor(
-                    Settings.Secure.DEV_FORCE_SHOW_NAVBAR), false, this,
+            resolver.registerContentObserver(CMSettings.Secure.getUriFor(
+                    CMSettings.Secure.DEV_FORCE_SHOW_NAVBAR), false, this,
                     UserHandle.USER_ALL);
             resolver.registerContentObserver(Settings.System.getUriFor(
                     Settings.System.VOLBTN_MUSIC_CONTROLS), false, this,
@@ -2189,8 +2186,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                 updateEdgeGestureListenerState();
             }
 
-            boolean devForceNavbar = Settings.Secure.getIntForUser(resolver,
-                    Settings.Secure.DEV_FORCE_SHOW_NAVBAR, 0, UserHandle.USER_CURRENT) == 1;
+            boolean devForceNavbar = CMSettings.Secure.getIntForUser(resolver,
+                    CMSettings.Secure.DEV_FORCE_SHOW_NAVBAR, 0, UserHandle.USER_CURRENT) == 1;
             if (devForceNavbar != mDevForceNavbar) {
                 mDevForceNavbar = devForceNavbar;
             }
@@ -3478,8 +3475,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             }
             return -1;
         } else if (keyCode == KeyEvent.KEYCODE_BACK) {
-            if (Settings.Secure.getInt(mContext.getContentResolver(),
-                    Settings.Secure.KILL_APP_LONGPRESS_BACK, 0) == 1) {
+            if (CMSettings.Secure.getInt(mContext.getContentResolver(),
+                    CMSettings.Secure.KILL_APP_LONGPRESS_BACK, 0) == 1) {
                 if (down && repeatCount == 0) {
                     mHandler.postDelayed(mBackLongPress, mBackKillTimeout);
                 }

--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -675,14 +675,14 @@ public final class PowerManagerService extends SystemService
             resolver.registerContentObserver(Settings.Secure.getUriFor(
                     Settings.Secure.DOUBLE_TAP_TO_WAKE),
                     false, mSettingsObserver, UserHandle.USER_ALL);
-            resolver.registerContentObserver(Settings.Secure.getUriFor(
-                    Settings.Secure.BUTTON_BRIGHTNESS),
+            resolver.registerContentObserver(CMSettings.Secure.getUriFor(
+                    CMSettings.Secure.BUTTON_BRIGHTNESS),
                     false, mSettingsObserver, UserHandle.USER_ALL);
-            resolver.registerContentObserver(Settings.Secure.getUriFor(
-                    Settings.Secure.KEYBOARD_BRIGHTNESS),
+            resolver.registerContentObserver(CMSettings.Secure.getUriFor(
+                    CMSettings.Secure.KEYBOARD_BRIGHTNESS),
                     false, mSettingsObserver, UserHandle.USER_ALL);
-            resolver.registerContentObserver(Settings.Secure.getUriFor(
-                    Settings.Secure.BUTTON_BACKLIGHT_TIMEOUT),
+            resolver.registerContentObserver(CMSettings.Secure.getUriFor(
+                    CMSettings.Secure.BUTTON_BACKLIGHT_TIMEOUT),
                     false, mSettingsObserver, UserHandle.USER_ALL);
             resolver.registerContentObserver(CMSettings.System.getUriFor(
                     CMSettings.System.PROXIMITY_ON_WAKE),
@@ -824,15 +824,15 @@ public final class PowerManagerService extends SystemService
             updateLowPowerModeLocked();
         }
 
-        mButtonTimeout = Settings.Secure.getIntForUser(resolver,
-                Settings.Secure.BUTTON_BACKLIGHT_TIMEOUT,
+        mButtonTimeout = CMSettings.Secure.getIntForUser(resolver,
+                CMSettings.Secure.BUTTON_BACKLIGHT_TIMEOUT,
                 DEFAULT_BUTTON_ON_DURATION, UserHandle.USER_CURRENT);
 
-        mButtonBrightness = Settings.Secure.getIntForUser(resolver,
-                Settings.Secure.BUTTON_BRIGHTNESS, mButtonBrightnessSettingDefault,
+        mButtonBrightness = CMSettings.Secure.getIntForUser(resolver,
+                CMSettings.Secure.BUTTON_BRIGHTNESS, mButtonBrightnessSettingDefault,
                 UserHandle.USER_CURRENT);
-        mKeyboardBrightness = Settings.Secure.getIntForUser(resolver,
-                Settings.Secure.KEYBOARD_BRIGHTNESS, mKeyboardBrightnessSettingDefault,
+        mKeyboardBrightness = CMSettings.Secure.getIntForUser(resolver,
+                CMSettings.Secure.KEYBOARD_BRIGHTNESS, mKeyboardBrightnessSettingDefault,
                 UserHandle.USER_CURRENT);
 
         mDirty |= DIRTY_SETTINGS;

--- a/services/core/java/com/android/server/power/ShutdownThread.java
+++ b/services/core/java/com/android/server/power/ShutdownThread.java
@@ -65,6 +65,8 @@ import android.util.Log;
 import android.view.IWindowManager;
 import android.view.WindowManager;
 import java.lang.reflect.Method;
+
+import cyanogenmod.providers.CMSettings;
 import dalvik.system.PathClassLoader;
 
 import java.io.BufferedReader;
@@ -170,8 +172,8 @@ public final class ShutdownThread extends Thread {
     private static boolean isAdvancedRebootPossible(final Context context) {
         KeyguardManager km = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
         boolean keyguardLocked = km.inKeyguardRestrictedInputMode() && km.isKeyguardSecure();
-        boolean advancedRebootEnabled = Settings.Secure.getInt(context.getContentResolver(),
-            Settings.Secure.ADVANCED_REBOOT, 0) == 1;
+        boolean advancedRebootEnabled = CMSettings.Secure.getInt(context.getContentResolver(),
+                CMSettings.Secure.ADVANCED_REBOOT, 0) == 1;
         boolean isPrimaryUser = UserHandle.getCallingUserId() == UserHandle.USER_OWNER;
 
         return advancedRebootEnabled && !keyguardLocked && isPrimaryUser;
@@ -190,8 +192,8 @@ public final class ShutdownThread extends Thread {
         boolean showRebootOption = false;
 
         String[] actionsArray;
-        String actions = Settings.Secure.getStringForUser(context.getContentResolver(),
-                Settings.Secure.POWER_MENU_ACTIONS, UserHandle.USER_CURRENT);
+        String actions = CMSettings.Secure.getStringForUser(context.getContentResolver(),
+                CMSettings.Secure.POWER_MENU_ACTIONS, UserHandle.USER_CURRENT);
         if (actions == null) {
             actionsArray = context.getResources().getStringArray(
                     com.android.internal.R.array.config_globalActionsList);

--- a/services/java/com/android/server/SystemServer.java
+++ b/services/java/com/android/server/SystemServer.java
@@ -102,6 +102,7 @@ import com.android.server.wallpaper.WallpaperManagerService;
 import com.android.server.webkit.WebViewUpdateService;
 import com.android.server.wm.WindowManagerService;
 
+import cyanogenmod.providers.CMSettings;
 import dalvik.system.VMRuntime;
 
 import java.io.File;
@@ -189,8 +190,8 @@ public final class SystemServer {
         }
         @Override
         public void onChange(boolean selfChange) {
-            int adbPort = Settings.Secure.getInt(mContentResolver,
-                Settings.Secure.ADB_PORT, 0);
+            int adbPort = CMSettings.Secure.getInt(mContentResolver,
+                CMSettings.Secure.ADB_PORT, 0);
             // setting this will control whether ADB runs on TCP/IP or USB
             SystemProperties.set("service.adb.tcp.port", Integer.toString(adbPort));
         }
@@ -1048,12 +1049,12 @@ public final class SystemServer {
         }
 
         // make sure the ADB_ENABLED setting value matches the secure property value
-        Settings.Secure.putInt(mContentResolver, Settings.Secure.ADB_PORT,
+        CMSettings.Secure.putInt(mContentResolver, CMSettings.Secure.ADB_PORT,
                 Integer.parseInt(SystemProperties.get("service.adb.tcp.port", "-1")));
 
         // register observer to listen for settings changes
         mContentResolver.registerContentObserver(
-            Settings.Secure.getUriFor(Settings.Secure.ADB_PORT),
+            CMSettings.Secure.getUriFor(CMSettings.Secure.ADB_PORT),
             false, new AdbPortObserver());
 
         // Before things start rolling, be sure we have decided whether

--- a/services/usb/Android.mk
+++ b/services/usb/Android.mk
@@ -9,4 +9,6 @@ LOCAL_SRC_FILES += \
 
 LOCAL_JAVA_LIBRARIES := services.core
 
+LOCAL_JAVA_LIBRARIES += org.cyanogenmod.platform.internal
+
 include $(BUILD_STATIC_JAVA_LIBRARY)

--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
@@ -51,6 +51,7 @@ import android.util.Slog;
 import com.android.internal.annotations.GuardedBy;
 import com.android.internal.util.IndentingPrintWriter;
 import com.android.server.FgThread;
+import cyanogenmod.providers.CMSettings;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -356,10 +357,10 @@ public class UsbDeviceManager {
                 };
 
                 mContentResolver.registerContentObserver(
-                        Settings.Secure.getUriFor(Settings.Secure.ADB_PORT),
+                        CMSettings.Secure.getUriFor(CMSettings.Secure.ADB_PORT),
                                 false, adbNotificationObserver);
                 mContentResolver.registerContentObserver(
-                        Settings.Secure.getUriFor(Settings.Secure.ADB_NOTIFY),
+                        CMSettings.Secure.getUriFor(CMSettings.Secure.ADB_NOTIFY),
                                 false, adbNotificationObserver);
 
                 // Watch for USB configuration changes
@@ -809,10 +810,10 @@ public class UsbDeviceManager {
             final int id;
             boolean usbAdbActive = mAdbEnabled && mConnected;
             boolean netAdbActive = mAdbEnabled &&
-                    Settings.Secure.getInt(mContentResolver, Settings.Secure.ADB_PORT, -1) > 0;
+                    CMSettings.Secure.getInt(mContentResolver, CMSettings.Secure.ADB_PORT, -1) > 0;
             boolean hideNotification = "0".equals(SystemProperties.get("persist.adb.notify"))
-                    || Settings.Secure.getInt(mContext.getContentResolver(),
-                            Settings.Secure.ADB_NOTIFY, 1) == 0;
+                    || CMSettings.Secure.getInt(mContext.getContentResolver(),
+                            CMSettings.Secure.ADB_NOTIFY, 1) == 0;
 
             if (hideNotification) {
                 id = 0;


### PR DESCRIPTION
This moves all Settings.Secure.\* settings that, were added to
CyanogenMod, to CMSettings.
- KEYBOARD_BRIGHTNESS
- BUTTON_BRIGHTNESS
- BUTTON_BACKLIGHT_TIMEOUT
- DEV_FORCE_SHOW_NAVBAR
- ADB_NOTIFY
- ADB_PORT
- DEVICE_HOSTNAME
- KILL_APP_LONGPRESS_BACK
- PROTECTED_COMPONENTS
- LIVE_DISPLAY_COLOR_MATRIX
- ADVANCED_REBOOT
- POWER_MENU_ACTIONS
- DEFAULT_THEME_COMPONENTS
- THEME_PREV_BOOT_API_LEVEL

Change-Id: I49e9160177ffc727b20008817ac2b5ce5e89ead5
