### PR TITLE
Tethering: Turn off Wi-Fi Hotspot after inactivity (1/3)

### DIFF
--- a/wifi/java/android/net/wifi/WifiConfiguration.java
+++ b/wifi/java/android/net/wifi/WifiConfiguration.java
@@ -456,6 +456,13 @@ public class WifiConfiguration implements Parcelable {
      */
     public int userApproved = USER_UNSPECIFIED;
 
+    /**
+     * @hide
+     * Inactivity time before wifi tethering is disabled.  Here inactivity means no clients
+     * connected.  A value of 0 means the AP will not be disabled when there is no activity
+     */
+    public long wifiApInactivityTimeout;
+
     /** The Below RSSI thresholds are used to configure AutoJoin
      *  - GOOD/LOW/BAD thresholds are used so as to calculate link score
      *  - UNWANTED_SOFT are used by the blacklisting logic so as to handle
@@ -1556,6 +1563,7 @@ public class WifiConfiguration implements Parcelable {
             creationTime = source.creationTime;
             updateTime = source.updateTime;
             SIMNum = source.SIMNum;
+            wifiApInactivityTimeout = source.wifiApInactivityTimeout;
         }
     }
 
@@ -1638,6 +1646,7 @@ public class WifiConfiguration implements Parcelable {
         dest.writeInt(numNoInternetAccessReports);
         dest.writeInt(noInternetAccessExpected ? 1 : 0);
         dest.writeInt(SIMNum);
+        dest.writeLong(wifiApInactivityTimeout);
     }
 
     /** Implement the Parcelable interface {@hide} */
@@ -1717,6 +1726,7 @@ public class WifiConfiguration implements Parcelable {
                 config.numNoInternetAccessReports = in.readInt();
                 config.noInternetAccessExpected = in.readInt() != 0;
                 config.SIMNum = in.readInt();
+                config.wifiApInactivityTimeout = in.readLong();
                 return config;
             }
 


### PR DESCRIPTION
Turn off the Wi-Fi hotspot after a specified time of inactivity.
The hotspot is considered to be inactive when no clients are
connected to it.

Change-Id: Ife48d5254b06b4e80841d5970984ab9979574e07
